### PR TITLE
Add global setting support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Overview
 This is a simple Maven plugin for managing a [Moco] (https://github.com/dreamhead/moco) server. It can be used to consistently
 run a Moco server on demand or to automatically launch the server during some part of the Maven lifecycle (such as `integration-test`).
 
+[![Build Status](https://travis-ci.org/htynkn/moco-maven-plugin.svg?branch=master)](https://travis-ci.org/htynkn/moco-maven-plugin)
+
 Usage
 =============
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
-        <version>7</version>
+        <version>9</version>
     </parent>
 
     <name>Moco Maven Plugin</name>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
-            <version>4.2.1</version>
+            <version>4.3.6</version>
         </dependency>
     </dependencies>
 
@@ -86,7 +86,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.3</version>
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>

--- a/src/main/java/com/garrettheel/moco/AbstractMocoExecutionMojo.java
+++ b/src/main/java/com/garrettheel/moco/AbstractMocoExecutionMojo.java
@@ -17,7 +17,7 @@ public abstract class AbstractMocoExecutionMojo extends AbstractMojo {
     /**
      * The file containing the JSON configuration.
      */
-    @Parameter(required = true)
+    @Parameter(required = false)
     protected File configFile;
 
     /**
@@ -31,6 +31,11 @@ public abstract class AbstractMocoExecutionMojo extends AbstractMojo {
      */
     @Parameter(required = false)
     protected Integer stopPort;
+    /**
+     * The global settings file.
+     */
+    @Parameter(required = false)
+    protected File globalFile;
 
     public File getConfigFile() {
         return configFile;
@@ -57,12 +62,18 @@ public abstract class AbstractMocoExecutionMojo extends AbstractMojo {
     }
 
     protected void checkParams() throws MojoExecutionException {
-        if (!configFile.exists()) {
+        if (fileNotExist(configFile)) {
             throw new MojoExecutionException("Moco config file does not exist.");
+        }
+        if (fileNotExist(globalFile)) {
+            throw new MojoExecutionException("Moco global config file does not exist.");
         }
         if (port == null || port < 1) {
             throw new MojoExecutionException("Invalid port number specified.");
         }
     }
 
+    protected boolean fileNotExist(File file) {
+        return file != null && !file.exists();
+    }
 }

--- a/src/main/java/com/garrettheel/moco/MocoRunMojo.java
+++ b/src/main/java/com/garrettheel/moco/MocoRunMojo.java
@@ -3,6 +3,7 @@ package com.garrettheel.moco;
 import com.github.dreamhead.moco.bootstrap.StartArgs;
 import com.github.dreamhead.moco.runner.JsonRunner;
 import com.github.dreamhead.moco.runner.Runner;
+import com.github.dreamhead.moco.runner.SettingRunner;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -15,7 +16,7 @@ import java.util.Arrays;
  * Runs a Moco server with a config file and port number. Note that the server will run
  * synchronously and can be stopped by killing the process.
  */
-@Mojo( name="run" )
+@Mojo(name = "run")
 public class MocoRunMojo extends AbstractMocoExecutionMojo {
 
     @Override
@@ -25,7 +26,11 @@ public class MocoRunMojo extends AbstractMocoExecutionMojo {
         Runner runner;
         try {
             StartArgs args = new StartArgs(port, null, null, null, null, null);
-            runner = JsonRunner.newJsonRunnerWithStreams(Arrays.asList(new FileInputStream(configFile)), args);
+            if (configFile != null) {
+                runner = JsonRunner.newJsonRunnerWithStreams(Arrays.asList(new FileInputStream(configFile)), args);
+            } else {
+                runner = new SettingRunner(new FileInputStream(globalFile), args);
+            }
         } catch (FileNotFoundException e) {
             throw new MojoExecutionException("Unable to load config file", e);
         }

--- a/src/main/java/com/garrettheel/moco/MocoStartMojo.java
+++ b/src/main/java/com/garrettheel/moco/MocoStartMojo.java
@@ -17,7 +17,12 @@ public class MocoStartMojo extends AbstractMocoExecutionMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         checkParams();
 
-        StartArgs startArgs = new StartArgs(port, stopPort, configFile.getAbsolutePath(), null, null, null);
+        StartArgs startArgs;
+        if (configFile != null) {
+            startArgs = new StartArgs(port, stopPort, configFile.getAbsolutePath(), null, null, null);
+        } else {
+            startArgs = new StartArgs(port, stopPort, null, globalFile.getAbsolutePath(), null, null);
+        }
         ShutdownRunner runner = new RunnerFactory(MONITOR_KEY).createRunner(startArgs);
         runner.run();
 

--- a/src/test/java/com/garrettheel/moco/AbstractMocoMojoTest.java
+++ b/src/test/java/com/garrettheel/moco/AbstractMocoMojoTest.java
@@ -1,11 +1,26 @@
 package com.garrettheel.moco;
 
+import com.garrettheel.moco.util.Waiter;
+import org.apache.http.client.fluent.Request;
 import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+
+import java.io.IOException;
+
+import static com.garrettheel.moco.util.Waiter.Condition;
 
 public abstract class AbstractMocoMojoTest extends AbstractMojoTestCase {
 
     private final static String MOCO_URI = "http://localhost:%d";
+    private final Waiter waiter;
+
+    protected AbstractMocoMojoTest() {
+        waiter = new Waiter();
+    }
+
+    public Waiter getWaiter() {
+        return waiter;
+    }
 
     protected Runnable getMojoExecutionTask(final Mojo mojo) {
         return new Runnable() {
@@ -18,6 +33,20 @@ public abstract class AbstractMocoMojoTest extends AbstractMojoTestCase {
                 }
             }
         };
+    }
+
+    protected void waitForMocoStartCompleted(final int port) {
+        waiter.until(new Condition() {
+            @Override
+            public boolean check() {
+                try {
+                    Request.Get(getMocoUri(port)).execute();
+                    return true;
+                } catch (IOException e) {
+                    return false;
+                }
+            }
+        });
     }
 
     protected String getMocoUri(int port) {

--- a/src/test/java/com/garrettheel/moco/AbstractMocoMojoTest.java
+++ b/src/test/java/com/garrettheel/moco/AbstractMocoMojoTest.java
@@ -53,4 +53,23 @@ public abstract class AbstractMocoMojoTest extends AbstractMojoTestCase {
         return String.format(MOCO_URI, port);
     }
 
+    protected boolean isServerShutdown(final String uri) throws Exception {
+        getWaiter().until(new Condition() {
+            @Override
+            public boolean check() {
+                try {
+                    Request.Get(uri).execute();
+                    return false;
+                } catch (IOException e) {
+                    return true;
+                }
+            }
+        }, new Waiter.TimeOutCallBack() {
+            @Override
+            public void execute() {
+                fail();
+            }
+        });
+        return true;
+    }
 }

--- a/src/test/java/com/garrettheel/moco/MocoGlobalMojoTest.java
+++ b/src/test/java/com/garrettheel/moco/MocoGlobalMojoTest.java
@@ -35,4 +35,26 @@ public class MocoGlobalMojoTest extends AbstractMocoMojoTest {
         executorService.shutdownNow();
         executorService.awaitTermination(1, TimeUnit.SECONDS);
     }
+
+    public void testStart() throws Exception {
+        File pom = getTestFile("src/test/resources/test-global-pom.xml");
+        assertTrue(pom.exists());
+
+        MocoStartMojo startMojo = (MocoStartMojo) lookupMojo("start", pom);
+        MocoStopMojo stopMojo = (MocoStopMojo) lookupMojo("stop", pom);
+        String mocoUri = getMocoUri(startMojo.getPort());
+
+        assertNotNull(startMojo);
+        assertNotNull(stopMojo);
+
+        startMojo.execute();
+
+        waitForMocoStartCompleted(startMojo.getPort());
+        String getResponse = Request.Get(mocoUri).execute().returnContent().asString();
+        assertEquals("bar", getResponse);
+
+        stopMojo.execute();
+
+        assertTrue(isServerShutdown(mocoUri));
+    }
 }

--- a/src/test/java/com/garrettheel/moco/MocoGlobalMojoTest.java
+++ b/src/test/java/com/garrettheel/moco/MocoGlobalMojoTest.java
@@ -1,0 +1,38 @@
+package com.garrettheel.moco;
+
+import org.apache.http.client.fluent.Request;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class MocoGlobalMojoTest extends AbstractMocoMojoTest {
+
+    @Before
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Test
+    public void testRun() throws Exception {
+        File pom = getTestFile("src/test/resources/test-global-pom.xml");
+        assertTrue(pom.exists());
+
+        final MocoRunMojo runMojo = (MocoRunMojo) lookupMojo("run", pom);
+        assertNotNull(runMojo);
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(getMojoExecutionTask(runMojo));
+
+        waitForMocoStartCompleted(runMojo.getPort());
+
+        String getResponse = Request.Get(getMocoUri(runMojo.getPort())).execute().returnContent().asString();
+        assertEquals("bar", getResponse);
+
+        executorService.shutdownNow();
+        executorService.awaitTermination(1, TimeUnit.SECONDS);
+    }
+}

--- a/src/test/java/com/garrettheel/moco/MocoRunMojoTest.java
+++ b/src/test/java/com/garrettheel/moco/MocoRunMojoTest.java
@@ -1,7 +1,6 @@
 package com.garrettheel.moco;
 
 import org.apache.http.client.fluent.Request;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,6 +26,8 @@ public class MocoRunMojoTest extends AbstractMocoMojoTest {
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(getMojoExecutionTask(runMojo));
+
+        waitForMocoStartCompleted(runMojo.getPort());
 
         String getResponse = Request.Get(getMocoUri(runMojo.getPort())).execute().returnContent().asString();
         assertEquals("foo", getResponse);

--- a/src/test/java/com/garrettheel/moco/MocoStartStopMojoTest.java
+++ b/src/test/java/com/garrettheel/moco/MocoStartStopMojoTest.java
@@ -1,14 +1,10 @@
 package com.garrettheel.moco;
 
-import com.garrettheel.moco.util.Waiter;
 import org.apache.http.client.fluent.Request;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
-
-import static com.garrettheel.moco.util.Waiter.Condition;
 
 public class MocoStartStopMojoTest extends AbstractMocoMojoTest {
 
@@ -38,7 +34,6 @@ public class MocoStartStopMojoTest extends AbstractMocoMojoTest {
         stopMojo.execute();
 
         assertTrue(isServerShutdown(mocoUri));
-
     }
 
     @Test
@@ -59,26 +54,6 @@ public class MocoStartStopMojoTest extends AbstractMocoMojoTest {
         stopMojo.execute();
 
         assertTrue(isServerShutdown(mocoUri));
-    }
-
-    private boolean isServerShutdown(final String uri) throws Exception {
-        getWaiter().until(new Condition() {
-            @Override
-            public boolean check() {
-                try {
-                    Request.Get(uri).execute();
-                    return false;
-                } catch (IOException e) {
-                    return true;
-                }
-            }
-        }, new Waiter.TimeOutCallBack() {
-            @Override
-            public void execute() {
-                fail();
-            }
-        });
-        return true;
     }
 
 }

--- a/src/test/java/com/garrettheel/moco/util/Waiter.java
+++ b/src/test/java/com/garrettheel/moco/util/Waiter.java
@@ -20,6 +20,7 @@ public class Waiter {
     public void until(Condition condition, TimeOutCallBack back) {
         boolean flag = true;
         int count = 0;
+
         do {
             if (condition.check()) {
                 flag = false;
@@ -32,6 +33,7 @@ public class Waiter {
             }
             count += interval;
         } while (flag && count < max);
+
         if (flag) {
             if (back == null) {
                 throw new timeOutException();

--- a/src/test/java/com/garrettheel/moco/util/Waiter.java
+++ b/src/test/java/com/garrettheel/moco/util/Waiter.java
@@ -8,8 +8,9 @@ public class Waiter {
 
     }
 
-    public Waiter(int interval) {
+    public Waiter(int interval, int max) {
         this.interval = interval;
+        this.max = max;
     }
 
     public void until(Condition condition) {

--- a/src/test/java/com/garrettheel/moco/util/Waiter.java
+++ b/src/test/java/com/garrettheel/moco/util/Waiter.java
@@ -1,0 +1,54 @@
+package com.garrettheel.moco.util;
+
+public class Waiter {
+    private int interval = 500;
+    private int max = 10000;
+
+    public Waiter() {
+
+    }
+
+    public Waiter(int interval) {
+        this.interval = interval;
+    }
+
+    public void until(Condition condition) {
+        until(condition, null);
+    }
+
+    public void until(Condition condition, TimeOutCallBack back) {
+        boolean flag = true;
+        int count = 0;
+        do {
+            if (condition.check()) {
+                flag = false;
+            } else {
+                try {
+                    Thread.sleep(interval);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+            count += interval;
+        } while (flag && count < max);
+        if (flag) {
+            if (back == null) {
+                throw new timeOutException();
+            } else {
+                back.execute();
+            }
+        }
+    }
+
+    public interface Condition {
+        boolean check();
+    }
+
+    public interface TimeOutCallBack {
+        void execute();
+    }
+
+    private class timeOutException extends RuntimeException {
+    }
+}
+

--- a/src/test/resources/moco-test-bar-config.json
+++ b/src/test/resources/moco-test-bar-config.json
@@ -1,0 +1,7 @@
+[
+    {
+        "response": {
+            "text": "bar"
+        }
+    }
+]

--- a/src/test/resources/moco-test-global-config.json
+++ b/src/test/resources/moco-test-global-config.json
@@ -1,0 +1,5 @@
+[
+    {
+        "include": "src/test/resources/moco-test-bar-config.json"
+    }
+]

--- a/src/test/resources/test-global-pom.xml
+++ b/src/test/resources/test-global-pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.garrettheel</groupId>
+    <artifactId>moco-maven-plugin-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>moco-maven-plugin Test</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.garrettheel</groupId>
+                <artifactId>moco-maven-plugin</artifactId>
+                <configuration>
+                    <port>8081</port>
+                    <globalFile>src/test/resources/moco-test-global-config.json</globalFile>
+                    <stopPort>8082</stopPort>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>


### PR DESCRIPTION
Hi GarrettHeel,

I use this plugin in current project. The config file for moco become bigger and bigger, now it's 1890 lines.

I check the moco document and I find [global setting](https://github.com/dreamhead/moco/blob/master/moco-doc/global-settings.md) is a very good solution for this situation.

I add the global setting support in this plugin.

And some small changes as below:
- add travis support (Please change the travis status image link in README.md to your repo)
- add a Waiter class to make test more stable
- update some dependency version

Please take a look at this PR. If you think it's ok to merge, could you deploy plugin with these changes to mvnrepository?

Thank you
